### PR TITLE
support creating a dud in rpm format (bsc #1006175)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ want to use your own scripts with such a name, specify it e.g. as
 ### DUD formats
 
 The DUD will be packaged into an archive and optionally compressed. The
-default is a gzipped cpio archive.
+default is a gzipped cpio archive. For SLE12 and later you can also
+create an rpm.
 
 Situation prior to SLE12, openSUSE 13.2:
 
@@ -130,8 +131,10 @@ SLE12, openSUSE 13.2, and later versions:
 
 >  You can use either a cpio or tar archive and can compress it optionally
 >  with either gzip or xz. All formats may be used for signed DUDs.
+>
+>  If you create an rpm you can sign the rpm in the usual rpm-way to get a signed DUD.
 
-There is an advantage in using cpio instead of tar: because the Linux kernel
+There is an advantage in using cpio instead of tar or rpm: because the Linux kernel
 understands cpio archives, you can just append a DUD to the initrd on the
 boot medium to apply it (literally: 'cat my.dud >> initrd'). No need for a
 'dud' boot option in this case.

--- a/README.md
+++ b/README.md
@@ -131,8 +131,11 @@ SLE12, openSUSE 13.2, and later versions:
 
 >  You can use either a cpio or tar archive and can compress it optionally
 >  with either gzip or xz. All formats may be used for signed DUDs.
->
->  If you create an rpm you can sign the rpm in the usual rpm-way to get a signed DUD.
+
+SLE12-SP1, Leap-42.1 and later versions:
+
+> If you create an RPM (use --format=rpm) you can sign the RPM in the usual RPM-way
+> to get a signed DUD.
 
 There is an advantage in using cpio instead of tar or rpm: because the Linux kernel
 understands cpio archives, you can just append a DUD to the initrd on the

--- a/mkdud
+++ b/mkdud
@@ -280,6 +280,7 @@ if($opt_create) {
     die "Error: distribution arg is required; use --dist.\n" if !@opt_dist;
     my %d;
     @dists = @opt_dist;
+    map { tr/-//d } @dists;
     map { s/^(tumbleweed|tw).*/tw/g } @dists;
     push @dists, "13.2" if grep { $_ eq "leap42.1" } @dists;
     @d{map { /^sle([sd]?)(\d+)/i ? $1 eq "" ? ("sles$2", "sled$2") : "sle\L$1$2" : "\L$_" } @dists} = ();

--- a/mkdud
+++ b/mkdud
@@ -117,6 +117,8 @@ sub import_sign_key;
 sub get_sign_key_name;
 sub sign_file;
 sub get_obs_key;
+sub repack_as_rpm;
+sub sign_rpm;
 
 my %config;
 my $opt_create;
@@ -152,8 +154,10 @@ my %arch;
 my $use_all_archs = 0;
 my $format_archive = "cpio";
 my $format_compr = "gz";
+my $format_rpm = 0;		# re-package as rpm if set
 my $sign_key_dir;
 my $sign_key_ok;
+my $sign_key_id;
 my $obs;
 my $pubkey_info;
 my $yast_version = 0;
@@ -1533,11 +1537,20 @@ sub write_dud
 
   system "cd $tmp_src; $cmd_archive | $compr >$tmp_archive";
 
+  if($format_rpm) {
+    $tmp_archive = repack_as_rpm $tmp_archive;
+  }
+
   if($opt_sign) {
-    sign_file $tmp_archive;
-    if(!$opt_sign_direct) {
-      system "cp ${tmp_archive}.asc ${file_name}.asc";
-      print "created detached signature ${file_name}.asc\n";
+    if($format_rpm) {
+      sign_rpm $tmp_archive;
+    }
+    else {
+      sign_file $tmp_archive;
+      if(!$opt_sign_direct) {
+        system "cp ${tmp_archive}.asc ${file_name}.asc";
+        print "created detached signature ${file_name}.asc\n";
+      }
     }
   }
 
@@ -2165,6 +2178,10 @@ sub set_format
 
     # print "format = $format_archive.$format_compr\n";
   }
+  elsif($opt_format eq 'rpm') {
+    $format_archive = 'tar';
+    $format_rpm = 1;
+  }
   else {
     die "$opt_format: unsupported format spec\n";
   }
@@ -2199,6 +2216,7 @@ sub import_sign_key
 
   if($priv && $date) {
     $sign_key_ok = 1;
+    $sign_key_id = $keyid;
 
     system "gpg --homedir=$sign_key_dir --import $key >/dev/null 2>&1";
 
@@ -2334,4 +2352,70 @@ sub vercmp {
   $s1 =~ s/(\d+)/sprintf("%010d", $1)/ge;
   $s2 =~ s/(\d+)/sprintf("%010d", $1)/ge;
   return $s1 cmp $s2;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# $new_file = repack_as_rpm($file)
+#
+# Re-pack archive $file as rpm. Returns the rpm name.
+#
+sub repack_as_rpm
+{
+  my $tmp_dir = $tmp->dir('rpm');
+  my $file = $_[0];
+
+  mkdir "$tmp_dir/SOURCES", 0755;
+  link $file, "$tmp_dir/SOURCES/dud.tar" or die "$file: $!\n";
+
+  my $c = <<'= = = = = = = =';
+Name:           dud
+Summary:        Driver Update
+License:        No License Info
+Group:          Other
+Version:        1.0
+Release:        0
+Source:         dud.tar
+BuildRoot:      %{_tmppath}/dud-build
+BuildArch:      noarch
+
+%description
+Driver Update
+
+%prep
+%setup -c dud -n dud
+%build
+%install
+  cp -a * %{buildroot}
+
+%files
+%defattr(-,root,root)
+/
+= = = = = = = =
+
+  open my $f, ">$tmp_dir/SOURCES/dud.spec";
+  print $f $c;
+  close $f;
+
+  system "rpmbuild -D '%_topdir $tmp_dir' -bb $tmp_dir/SOURCES/dud.spec >$tmp_dir/build.log 2>&1";
+
+  my $rpm_name = "$tmp_dir/RPMS/noarch/dud-1.0-0.noarch.rpm";
+
+  die "failed to create rpm\n" unless -f $rpm_name;
+
+  return $rpm_name;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Sign an rpm.
+#
+sub sign_rpm
+{
+  my $file = $_[0];
+
+  return if !$sign_key_ok;
+
+  # note: the 'setsid' is needed because rpmsign will try to read the passphrase from /dev/tty
+  system "setsid rpmsign --addsign -D '%_gpg_path $sign_key_dir' -D '%_gpg_name $sign_key_id' $file </dev/null >$sign_key_dir/rpmsign.log 2>&1";
 }

--- a/mkdud
+++ b/mkdud
@@ -605,6 +605,17 @@ sub file_type
       exit 1;
     }
 
+    # check if rpm contains a driver update
+    # (a directory /linux/suse/foo-bar or /<NUMBER>/linux/suse/foo-bar exists)
+    for my $l (`rpm --nosignature -qp -lv $_[0] 2>$tmp_err`) {
+      my @l = split ' ', $l;
+      next unless $l[0] =~ /^d/;
+      if($l[8] =~ m#/(\d+/)?linux/suse/\S+-\S+$#) {
+        $dud = 'cpio.rpm';
+        last;
+      }
+    }
+
     # Check if yast base package is to be replaced and remember its version:
     if($f =~ /^yast2\t(.+)\t/) {
       $yast_version = $1;
@@ -623,18 +634,20 @@ sub file_type
 
     $ft->{date} = $d;
 
-    push @files, $ft;
+    if(!$dud) {
+      push @files, $ft;
 
-    if($opt_obs_keys && $opt_install{repo}) {
-      my $x = `rpm --nosignature -qp -i $_[0] 2>$tmp_err`;
-      if($x =~ /^Signature\s*:.*Key ID/m) {
-        $x = `rpm --nosignature -qp --qf '%{DISTURL}' $_[0] 2>$tmp_err`;
-        $x = get_obs_key $x, $_[0];
-        push @files, { type => 'pubkey', file => $x } if $x;
+      if($opt_obs_keys && $opt_install{repo}) {
+        my $x = `rpm --nosignature -qp -i $_[0] 2>$tmp_err`;
+        if($x =~ /^Signature\s*:.*Key ID/m) {
+          $x = `rpm --nosignature -qp --qf '%{DISTURL}' $_[0] 2>$tmp_err`;
+          $x = get_obs_key $x, $_[0];
+          push @files, { type => 'pubkey', file => $x } if $x;
+        }
       }
-    }
 
-    return;
+      return;
+    }
   }
   elsif(/^ELF/) {
     @i = split /\s*,\s*/;
@@ -774,12 +787,13 @@ sub file_type
 
     my $old = sprintf "%s/%04d", $tmp_old, $dud_cnt++;
     die "$old: $!\n" unless mkdir $old;
-    if($dud =~ /^(cpio|tar)(\.(gz|xz))?$/) {
-      my $cmd = "cpio --quiet -dmiu";
+    if($dud =~ /^(cpio|tar)(\.(gz|xz|rpm))?$/) {
+      my $cmd = "cpio --quiet -dmiu --no-absolute-filenames";
       $cmd = "tar -xpf -" if $1 eq "tar";
       my $compr = 'cat';
       $compr = 'gzip -dc' if $3 eq 'gz';
       $compr = 'xz -dc' if $3 eq 'xz';
+      $compr = 'rpm2cpio' if $3 eq 'rpm';
       if($gpg_sign) {
         system "$gpg $_[0] | $compr | ( cd $old ; $cmd 2>/dev/null)";
       }

--- a/mkdud
+++ b/mkdud
@@ -614,10 +614,10 @@ sub file_type
 
     # check if rpm contains a driver update
     # (a directory /linux/suse/foo-bar or /<NUMBER>/linux/suse/foo-bar exists)
-    for my $l (`rpm --nosignature -qp -lv $_[0] 2>$tmp_err`) {
-      my @l = split ' ', $l;
-      next unless $l[0] =~ /^d/;
-      if($l[8] =~ m#/(\d+/)?linux/suse/\S+-\S+$#) {
+    for my $line (`rpm --nosignature -qp -lv $_[0] 2>$tmp_err`) {
+      my @field = split ' ', $line;
+      next unless $field[0] =~ /^d/;
+      if($field[8] =~ m#/(\d+/)?linux/suse/\S+-\S+$#) {
         $dud = 'cpio.rpm';
         last;
       }

--- a/mkdud
+++ b/mkdud
@@ -418,9 +418,10 @@ Create driver update:
                                 installation. mkdud will normally remove those files and
                                 print a warning. This also allows you to specify distributions
                                 with --dist that mkdud does not know about.
-      --format FORMAT           Specify archive format for DUD. FORMAT=(cpio|tar|iso)[.(gz|xz)].
+      --format FORMAT           Specify archive format for DUD.
+                                FORMAT=((cpio|tar|iso)[.(gz|xz)])|rpm.
                                 Default FORMAT is cpio.gz (gzip compressed cpio archive).
-                                Note: don't change the default. See README.
+                                Note: please check README before changing the default.
       --prefix NUM              First directory prefix of driver update. See README.
       --sign                    Sign the driver update.
       --detached-sign           Sign the driver update. This creates a detached signature.
@@ -444,10 +445,11 @@ Configuration file:
 
 To create a driver update you need SOURCES. SOURCES can contain:
 
-  - existing driver updates; either as archive or unpacked directory. All driver
+  - existing driver updates; either as archive, rpm, or unpacked directory. All driver
     updates are joined.
 
-  - RPMs. The packages are used according to the value of the --install option.
+  - RPMs. Packages not containing a driver update are used according to the value
+    of the --install option.
 
   - PGP pubic key files (ASCII). The files are added to the rpm key database for verifying
     RPMs during the installation process. See 'Adding RPMs notes' below.


### PR DESCRIPTION
In bsc #1006175 it became clear that there is some benefit in having a dud in rpm format. Mainly because you can comparatively easy get signed rpms (and so duds) out of the build service.

linuxrc supports this since sle12-sp1/leap-42.1