### PR TITLE
add --sign-key-id option to allow specifying a gpg signing key by id

### DIFF
--- a/mkdud
+++ b/mkdud
@@ -138,6 +138,7 @@ my $opt_format;
 my $opt_sign;
 my $opt_sign_direct;
 my $opt_sign_key;
+my $opt_sign_key_id;
 my $opt_dud_prefix;
 my $opt_vendor;
 my $opt_preparer;
@@ -196,6 +197,7 @@ GetOptions(
   'detached-sign'    => \$opt_sign,
   'sign'             => sub { $opt_sign = 1; $opt_sign_direct = 1 },
   'sign-key=s'       => \$opt_sign_key,
+  'sign-key-id=s'    => \$opt_sign_key_id,
   'obs-keys'         => \$opt_obs_keys,
   'force'            => sub { $opt_fix_yast = $opt_fix_usr_src = $opt_fix_dist = $opt_fix_adddir = 0 },
   'fix-yast!'        => \$opt_fix_yast,
@@ -241,6 +243,7 @@ if(open my $f, "$ENV{HOME}/.mkdudrc") {
 }
 
 $opt_sign_key ||= $config{'sign-key'};
+$opt_sign_key_id ||= $config{'sign-key-id'};
 
 if($opt_obs_keys) {
   my $f;
@@ -413,6 +416,7 @@ Create driver update:
       --sign                    Sign the driver update.
       --detached-sign           Sign the driver update creating a detached signature.
       --sign-key KEY_FILE       Use this key for signing.
+      --sign-key-id KEY_ID      Use this key id for signing (anything gpg accepts).
       --volume                  Set ISO volume id (if using format 'iso').
       --vendor                  Set ISO publisher id (if using format 'iso').
       --preparer                Set ISO data preparer id (if using format 'iso').
@@ -2117,6 +2121,17 @@ sub set_format
 sub import_sign_key
 {
   return if !$opt_sign;
+
+  if($opt_sign_key_id) {
+    $sign_key_ok = 1;
+    $sign_key_id = $opt_sign_key_id;
+    $sign_key_dir = "$ENV{HOME}/.gnupg";
+    die "$sign_key_dir: no such gpg directory\n" unless -d $sign_key_dir;
+
+    print "using signing key, keyid = $sign_key_id\n";
+
+    return;
+  }
 
   die "no sign key specified\n" if !$opt_sign_key;
 

--- a/mkdud_man.adoc
+++ b/mkdud_man.adoc
@@ -145,6 +145,12 @@ Sign the driver update. This creates a detached signature.
 *--sign-key*=_KEY_FILE_::
 Use this key for signing. Alternatively, use the `sign-key` entry in `~/.mkdudrc`.
 
+*--sign-key-id*=_KEY_ID_::
+Use this key id for signing (anything gpg accepts).
+Alternatively, use the `sign-key-id` entry in `~/.mkdudrc`. +
+If both *--sign-key* and *--sign-key-id* are specified, *--sign-key-id* wins. +
+*Note*: gpg might show an interactive dialog asking for a password to unlock the key.
+
 *--volume*::
 Set ISO volume id (if using format `iso`).
 
@@ -169,6 +175,9 @@ mkdud reads `$HOME/.mkdudrc` at startup. There's only one possible entry:
 
 *sign-key*=_KEY_FILE_::
 File name of the private signing key. The same as the *--sign-key* option.
+
+*sign-key-id*=_KEY_ID_::
+Key id of the signing key. The same as the *--sign-key-id* option.
 
 
 == Driver Update SOURCES


### PR DESCRIPTION
## Problem

So far, mkdud allowed only to use a secret key file to specify the signing key.

It is more useful to specify the key id that gpg should use.

## Solution

Add new `--sign-key-id` option that accepts a gpg key id.

**Note:** This implies that there might be an interactive password prompt to unlock the key.