### PR TITLE
ensure DUD repos are removed at the end of the installation (bsc#1173988)

### DIFF
--- a/mkdud
+++ b/mkdud
@@ -1207,9 +1207,9 @@ close F;
 dir=${0%/*/*}
 dir=${dir#/*/}
 
-repo="baseurl=dir:///$dir/repo"
+repo="baseurl=dir:(//)?/$dir/repo"
 
-for i in `grep -l $repo /etc/zypp/repos.d/*` ; do
+for i in `grep -El $repo /etc/zypp/repos.d/*` ; do
   [ -f "$i" ] && rm "$i"
 done
 = = = = = = = =


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1173988

The repo URI used to be `dir:///` (with triple slashes) - now it's `dir:/` (one slash).

## Solution

Match both cases.