### PR TITLE
adapt to support xz compressed kernel modules (bsc#1184550)

### DIFF
--- a/mkdud
+++ b/mkdud
@@ -97,6 +97,11 @@ our $VERSION = "0.0";
 my @all_archs = qw ( x86_64 aarch64 armv7l i386 ia64 ppc ppc64 ppc64le s390 s390x );
 my $REPLACEABLE_YAST = '3.1.135';
 
+# valid kernel module extensions
+my $kext_regexp = '\.ko(?:\.xz)?';
+my $kext_glob = '.ko{,.xz}';
+my @kext_list = qw ( .ko .ko.xz );
+
 sub usage;
 sub get_file_arch;
 sub file_type;
@@ -436,6 +441,9 @@ More information is available in the mkdud(1) manual page.
 #
 # Return architecture for $file or undef if it couldn't be determined.
 #
+# $file may optionally be xz or gzip compressed (with file extensions .xz
+# resp. .gz).
+#
 sub get_file_arch
 {
   my $file = $_[0];
@@ -456,6 +464,14 @@ sub get_file_arch
     'elf64-s390' => 's390x',
     'elf64-x86-64' => 'x86_64',
   };
+
+  if($file =~ /\.(gz|xz)$/) {
+    my $compr = 'gzip -dc';
+    $compr = 'xz -dc' if $1 eq 'xz';
+    my $tmp_file = $tmp->file();
+    system "$compr $file > $tmp_file";
+    $file = $tmp_file;
+  }
 
   for (`objdump -f $file 2>/dev/null`) {
     if(/ file format (\S+)$/) {
@@ -546,6 +562,23 @@ sub file_type
       return;
     }
   }
+  elsif($_[0] =~ m#${kext_regexp}$#) {
+    my $ft = { file => $_[0] };
+
+    my $ar = get_file_arch $_[0];
+    $ft->{arch} = $ar if defined $ar;
+
+    $ft->{type} = 'module';
+    @i = split " ", `modinfo -F vermagic $_[0] 2>/dev/null`;
+    $ft->{version} = $i[0];
+    my $v = `modinfo -F version $_[0] 2>/dev/null`;
+    chomp $v;
+    $ft->{mod_version} = $v if $v !~ /^\s*$/;
+
+    push @files, $ft;
+
+    return;
+  }
   elsif(/^ELF/) {
     @i = split /\s*,\s*/;
 
@@ -560,16 +593,6 @@ sub file_type
     }
     elsif($i[0] =~ /shared/) {
       $ft->{type} = 'lib';
-      push @files, $ft;
-    }
-    elsif($_[0] =~ m#\.ko$#) {
-      $ft->{type} = 'module';
-      @i = split " ", `modinfo -F vermagic $_[0] 2>/dev/null`;
-      $ft->{version} = $i[0];
-      my $v = `modinfo -F version $_[0] 2>/dev/null`;
-      chomp $v;
-      $ft->{mod_version} = $v if $v !~ /^\s*$/;
-
       push @files, $ft;
     }
 
@@ -1791,7 +1814,7 @@ sub show_single_dir
   # ----------------------------
   # modules
 
-  for (glob("$dir/modules/*.ko")) {
+  for (glob("$dir/modules/*${kext_glob}")) {
     my $f = $_;
     s#^.*/##;
     my $n = $_;


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1184550
- https://trello.com/c/iroG0VHx

Kernel modules in driver updates can have either a `*.ko` or `*.ko.xz` extension. Adjust mkdud to work with either variant.