### PR TITLE
add SLE Micro to the list of known products

### DIFF
--- a/mkdud
+++ b/mkdud
@@ -300,6 +300,8 @@ if($opt_create) {
     map { tr/-//d } @dists;
     # kubic is part of tumbleweed
     map { s/^(tumbleweed|tw|kubic).*/tw/g } @dists;
+    # map 'micro' to 'suse-microos'
+    map { s/^micro(\d)/suse-microos$1/ } @dists;
     # map 'casp' to the new 'caasp'
     map { s/^casp(\d)/caasp$1/ } @dists;
     # CaaSP should be aligned with the respective SLES
@@ -312,9 +314,13 @@ if($opt_create) {
     push @dists, "13.2" if grep { $_ eq "leap42.1" } @dists;
     @d{map { /^sle([sd]?)(\d+)/i ? $1 eq "" ? ("sles$2", "sled$2") : "sle\L$1$2" : "\L$_" } @dists} = ();
     @dists = sort keys %d;
+    @d{map { /^(\d+)\.(\d+)$/ && $1 >= 15 ? ("leap$1.$2", "sles$1", "sled$1") : $_ } @dists} = ();
+    @d{map { /^(\d+)$/ && $1 >= 15 ? ("sles$1", "sled$1") : $_ } @dists} = ();
+    @dists = sort keys %d;
+    @dists = grep { !(/^(\d+)(\.(\d+))?$/ && $1 >= 15) } @dists;
 
     for (@dists) {
-      if(!/^((leap|kubic|casp|caasp)?\d+\.\d+|tw|sle[sd]\d+)$/) {
+      if(!/^((leap|kubic|casp|caasp|suse-microos)?\d+\.\d+|tw|sle[sd]\d+)$/) {
         if(!$opt_fix_dist) {
           print STDERR "***  Note: using unsupported dist \"$_\"\n";
         }
@@ -401,7 +407,7 @@ Create driver update:
 
   -c, --create DUD              Create new driver update DUD from SOURCES.
   -a, --arch ARCH               Build for target ARCH (default: auto detected from SOURCES).
-  -d, --dist DIST               Specify the product the DUD is for (e.g. sle12).
+  -d, --dist DIST               Specify the product the DUD is for (e.g. sle15).
       --condition SCRIPT        Run SCRIPT and apply DUD only if SCRIPT has exit status 0.
   -p, --prio NUM                Set repository priority to NUM (default: 50).
   -n, --name NAME               Set driver update name.
@@ -1667,12 +1673,12 @@ sub nice_arch_list
 
   my %p1;
   for (@$l) {
-    if(/^(\S+)-(sle([sd])(\d+)|(leap|kubic|casp|caasp)?(\d+\.\d+)|tw)$/) {
+    if(/^(\S+)-(sle([sd])(\d+)|(leap|kubic|casp|caasp|suse-microos)?(\d+\.\d+)|tw)$/) {
       if($3 eq 's') {
-        push @{$p1{"SLES $4"}}, $1;
+        push @{$p1{"SUSE Linux Enterprise Server $4"}}, $1;
       }
       elsif($3 eq 'd') {
-        push @{$p1{"SLED $4"}}, $1;
+        push @{$p1{"SUSE Linux Enterprise Desktop $4"}}, $1;
       }
       elsif($5 eq 'leap') {
         push @{$p1{"openSUSE Leap $6"}}, $1;
@@ -1681,10 +1687,13 @@ sub nice_arch_list
         push @{$p1{"openSUSE Kubic $6"}}, $1;
       }
       elsif($5 eq 'casp') {
-        push @{$p1{"CASP $6"}}, $1;
+        push @{$p1{"SUSE Containers as a Service Platform $6"}}, $1;
       }
       elsif($5 eq 'caasp') {
-        push @{$p1{"CaaSP $6"}}, $1;
+        push @{$p1{"SUSE Containers as a Service Platform $6"}}, $1;
+      }
+      elsif($5 eq 'suse-microos') {
+        push @{$p1{"SUSE Linux Enterprise Micro $6"}}, $1;
       }
       elsif($2 eq "tw") {
         push @{$p1{"openSUSE Tumbleweed"}}, $1;
@@ -1709,9 +1718,9 @@ sub nice_arch_list
 
   for (sort keys %p2) {
     my $s = $_;
-    if($s =~ s/^SLED /SLES / && $p2{$s} eq $p2{$_}) {
+    if($s =~ s/ Desktop / Server / && $p2{$s} eq $p2{$_}) {
       my $e = $_;
-      $e =~ s/^SLED /SLE /;
+      $e =~ s/ Desktop / /;
       $p2{$e} = $p2{$_};
       delete $p2{$_};
       delete $p2{$s};

--- a/mkdud_man.adoc
+++ b/mkdud_man.adoc
@@ -51,8 +51,8 @@ architectures is created.
 
 *-d, --dist*=_DIST_::
 Specify the product the DUD is for. Possible values for _DIST_ include:
-`13.2`, `sle15`, `leap15.1`, `caasp1.0`, `tw` standing for
-openSUSE 13.2, SLE15, Leap 15.1, CaaSP 1.0, Tumbleweed, respectively. +
+`13.2`, `sle15`, `leap15.1`, `caasp1.0`, 'micro5.0', `tw` standing for
+openSUSE 13.2, SLE 15, Leap 15.1, CaaSP 1.0, SLE Micro 5.0, Tumbleweed, respectively. +
 *Note 1*: `sle15` is a short hand for specifying both `sles15` and `sled15`. +
 *Note 2*: There are no separate names for service packs.
 So `sles15-sp1` is the same as `sles15`. But see *--condition*
@@ -260,6 +260,14 @@ The *--dist* option accepts these values (case-insensitive; X, Y: decimal number
 - slesX (e.g. sles15) = SUSE Linux Enterprise Server X
 - sledX (e.g. sled15) = SUSE Linux Enterprise Desktop X - but see notes below
 - caaspX.Y (e.g. caasp1.0) = SUSE Container as a Service Platform X.Y - see notes below
+- microX.Y (e.g. micro5.0) = SUSE Linux Enterprise Micro X.Y
+
+As a shorthand and to avoid common mistakes, these aliases do also work (X, Y: decimal numbers):
+
+- X.Y with X >= 15 (e.g. 15.1) resolves to: +
+  SUSE Linux Enterprise (Server + Desktop) X + openSUSE Leap X.Y
+- X with X >= 15 (e.g. 15) resolves to: +
+  SUSE Linux Enterprise (Server + Desktop) X
 
 *Note 1*: there aren't any products anymore that actually use `sledX`,
 even SLED uses the `sles` DUDs meanwhile. Because of this, please just use `sleX`
@@ -278,8 +286,11 @@ Currently:
 Kubic is based on Tumbleweed. For compatibility, *--dist*=kubic... variants are still
 supported but will be mapped to Tumbleweed. Please use *--dist*=tw directly.
 
-Driver updates built for SLE12 will implicitly also work with
-CaaSP3.0; those built for SLE15 will implicitly also work with CaaSP4.0. But
+openSUSE MicroOS (not to be confused with SUSE Linux Enterprise Micro) is
+based on Tumbleweed. Use *--dist*=tw.
+
+Driver updates built for SLE 12 will implicitly also work with
+CaaSP3.0; those built for SLE 15 will implicitly also work with CaaSP4.0. But
 this is not true for CaaSP1.0 and CaaSP2.0.
 
 Normally, a DUD will apply to the main release as well as to all the service packs.


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1185844

- add `--dist=microX.Y` for SLE Micro

Plus, do some cleanup and small related improvements:

- add X.Y as shorthand for SLEX and Leap X.Y (common mistake)
- use full product names for SLES & SLED in output
- update documentation