### PR TITLE
do not preprocess dist names when the --no-fix-dist option is used (bsc#1199514)

### DIFF
--- a/mkdud
+++ b/mkdud
@@ -297,27 +297,30 @@ if($opt_create) {
     die "Error: distribution arg is required; use --dist.\n" if !@opt_dist;
     my %d;
     @dists = @opt_dist;
-    map { tr/-//d } @dists;
-    # kubic is part of tumbleweed
-    map { s/^(tumbleweed|tw|kubic).*/tw/g } @dists;
-    # map 'micro' to 'suse-microos'
-    map { s/^micro(\d)/suse-microos$1/ } @dists;
-    # map 'casp' to the new 'caasp'
-    map { s/^casp(\d)/caasp$1/ } @dists;
-    # CaaSP should be aligned with the respective SLES
-    # caasp1.0 = sle12 (-sp2)
-    # cassp2.0 = sle12 (-sp3)
-    # caasp3.0 = sle12 (-sp3)
-    # caasp4.0 = sle15
-    push @dists, "sles12" if grep { /^caasp[123]\./ } @dists;
-    push @dists, "sles15" if grep { /^caasp4\./ } @dists;
-    push @dists, "13.2" if grep { $_ eq "leap42.1" } @dists;
-    @d{map { /^sle([sd]?)(\d+)/i ? $1 eq "" ? ("sles$2", "sled$2") : "sle\L$1$2" : "\L$_" } @dists} = ();
-    @dists = sort keys %d;
-    @d{map { /^(\d+)\.(\d+)$/ && $1 >= 15 ? ("leap$1.$2", "sles$1", "sled$1") : $_ } @dists} = ();
-    @d{map { /^(\d+)$/ && $1 >= 15 ? ("sles$1", "sled$1") : $_ } @dists} = ();
-    @dists = sort keys %d;
-    @dists = grep { !(/^(\d+)(\.(\d+))?$/ && $1 >= 15) } @dists;
+
+    if($opt_fix_dist) {
+      map { tr/-//d } @dists;
+      # kubic is part of tumbleweed
+      map { s/^(tumbleweed|tw|kubic).*/tw/g } @dists;
+      # map 'micro' to 'suse-microos'
+      map { s/^micro(\d)/suse-microos$1/ } @dists;
+      # map 'casp' to the new 'caasp'
+      map { s/^casp(\d)/caasp$1/ } @dists;
+      # CaaSP should be aligned with the respective SLES
+      # caasp1.0 = sle12 (-sp2)
+      # cassp2.0 = sle12 (-sp3)
+      # caasp3.0 = sle12 (-sp3)
+      # caasp4.0 = sle15
+      push @dists, "sles12" if grep { /^caasp[123]\./ } @dists;
+      push @dists, "sles15" if grep { /^caasp4\./ } @dists;
+      push @dists, "13.2" if grep { $_ eq "leap42.1" } @dists;
+      @d{map { /^sle([sd]?)(\d+)/i ? $1 eq "" ? ("sles$2", "sled$2") : "sle\L$1$2" : "\L$_" } @dists} = ();
+      @dists = sort keys %d;
+      @d{map { /^(\d+)\.(\d+)$/ && $1 >= 15 ? ("leap$1.$2", "sles$1", "sled$1") : $_ } @dists} = ();
+      @d{map { /^(\d+)$/ && $1 >= 15 ? ("sles$1", "sled$1") : $_ } @dists} = ();
+      @dists = sort keys %d;
+      @dists = grep { !(/^(\d+)(\.(\d+))?$/ && $1 >= 15) } @dists;
+    }
 
     for (@dists) {
       if(!/^((leap|kubic|casp|caasp|suse-microos)?\d+\.\d+|tw|sle[sd]\d+)$/) {


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1199514

`mkdud --no-fix-dist foo-bar ...` will remove the dash (`-`) when constructing the final path name to use, ending up with `/linux/suse/x86_64-foobar`.

This makes it impossible to create dist name variants for `suse-microos`.

## Solution

Skip any preprocessing of dist names when `--no-fix-dist` is active.

This introduces a slight incompatibility to previous behavior but it is now more aligned to what the man page describes:

> --[no-]fix-dist
>           The --dist option normally allows you to specify only distributions mkdud knows about. With this option you may put anything there - in case you know better.
