### PR TITLE
Replace genisoimage with mkisofs

### DIFF
--- a/mkdud
+++ b/mkdud
@@ -1472,7 +1472,7 @@ sub write_dud
 
   if($format_archive eq 'iso') {
     set_mkisofs_metadata;
-    $cmd_archive = "genisoimage -l -r -pad -input-charset utf8";
+    $cmd_archive = "mkisofs -l -r -pad -input-charset utf8";
     $cmd_archive .= " -V '" . substr($opt_volume, 0, 32) . "'";
     $cmd_archive .= " -A '" . substr($opt_application, 0, 128) . "'";
     $cmd_archive .= " -p '" . substr($opt_preparer, 0, 128) . "'";


### PR DESCRIPTION
`mkdud --format=iso` creates an empty file:

```
$ mkdud --dist tumbleweed --create test.iso --format=iso HOWTO.md
===  Update #1  ===
  [Documentation]
    HOWTO.md
  [openSUSE Tumbleweed]
    Name:
      Update 0ac60dd9-0658-4031-bcf4-7a3bcccbec85
    ID:
      0ac60dd9-0658-4031-bcf4-7a3bcccbec85
$ echo $?
0
$ ls -l test.iso
-rw-r--r-- 1 mwilck suse     0 Sep 22 11:56 test.iso
```

The problem is that "--format=iso" requires the "genisoimage" tool, which is
unavailable under recent openSUSE releases (see bug 1100795).

Simply replacing genisoimage with mkisofs seems to work.
